### PR TITLE
[Feat#22] 이슈 통계정보 생성 및 전달

### DIFF
--- a/src/main/java/com/softgallery/issuemanagementbackEnd/controller/statistics/StatisticsController.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/controller/statistics/StatisticsController.java
@@ -1,0 +1,90 @@
+package com.softgallery.issuemanagementbackEnd.controller.statistics;
+
+import com.softgallery.issuemanagementbackEnd.dto.IssueDTO;
+import com.softgallery.issuemanagementbackEnd.dto.StatisticsDTO;
+import com.softgallery.issuemanagementbackEnd.exception.ObjectNotFoundException;
+import com.softgallery.issuemanagementbackEnd.service.statistics.StatisticsServiceIF;
+import java.util.HashMap;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+@RequestMapping("/statistics")
+public class StatisticsController {
+    private final StatisticsServiceIF statisticsService;
+
+    public StatisticsController(final StatisticsServiceIF statisticsService) {
+        this.statisticsService = statisticsService;
+    }
+
+    @PostMapping("/create")
+    public Boolean createIssueStatistics(@RequestBody IssueDTO issueDTO) {
+        return statisticsService.createIssueStatistics(issueDTO);
+    }
+
+    @GetMapping("/get/{statisticsId}")
+    public StatisticsDTO getStatisticsById(@PathVariable Long statisticsId) throws ObjectNotFoundException {
+        return statisticsService.getStatisticsByID(statisticsId);
+    }
+
+    // 여기서부터 전체 프로젝트의 이슈 대상
+    @GetMapping("/get/global/")
+    public Long getNumbers() {
+        return statisticsService.getNumberOfAllIssues();
+    }
+
+    @GetMapping("/get/global/priority")
+    public HashMap<String, Long> getNumbersByPriority() {
+        return statisticsService.getNumberOfAllIssuesByPriority();
+    }
+
+    @GetMapping("/get/global/mainCause")
+    public HashMap<String, Long> getNumbersByMainCause() {
+        return statisticsService.getNumberOfAllIssuesByMainCause();
+    }
+
+    @GetMapping("/get/global/state")
+    public HashMap<String, Long> getNumbersByState() {
+        return statisticsService.getNumberOfIssuesByState();
+    }
+
+
+    // 여기서부터는 특정 프로젝트의 이슈 대상
+    @GetMapping("/get/project/{projectId}")
+    public Long getNumberOfIssuesInProject(@PathVariable Long projectId) {
+        return statisticsService.getNumberOfIssuesByProject(projectId);
+    }
+
+    @GetMapping("/get/project/priority/{projectId}")
+    public HashMap<String, Long> getNumberOfIssuesByProjectAndPriority(@PathVariable Long projectId) {
+        return statisticsService.getNumberOfIssuesByProjectAndPriority(projectId);
+    }
+
+    @GetMapping("/get/project/mainCause/{projectId}")
+    public HashMap<String, Long> getNumberOfIssuesByProjectAndMainCause(@PathVariable Long projectId) {
+        return statisticsService.getNumberOfIssuesByProjectAndMainCause(projectId);
+    }
+
+    @GetMapping("/get/project/state/{projectId}")
+    public HashMap<String, Long> getNumbersByProjectAndState(@PathVariable Long projectId) {
+        return statisticsService.getNumberOfIssuesByProjectAndState(projectId);
+    }
+
+
+    @PostMapping("/update/{statisticsId}")
+    public Boolean updateIssueStatistics(@RequestBody StatisticsDTO statisticsDTO, @PathVariable Long statisticsId) throws ObjectNotFoundException {
+        return statisticsService.updateIssueStatistics(statisticsDTO, statisticsId);
+    }
+
+    @DeleteMapping("/delete/{statisticsId}")
+    public Boolean deleteIssueStatistics(@PathVariable Long statisticsId) {
+        return statisticsService.deleteIssueStatistics(statisticsId);
+    }
+}

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/dto/StatisticsDTO.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/dto/StatisticsDTO.java
@@ -1,11 +1,61 @@
 package com.softgallery.issuemanagementbackEnd.dto;
 
+import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
+import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
+import java.time.Duration;
+import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
 public class StatisticsDTO {
     private Long id;
     private Long issueId;
+    private Long projectId;
+    private Priority priority;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate = LocalDateTime.MIN;
+    private Long duration;
+    private MainCause mainCause;
+
+    // Duration(시간차) Long 값으로 전달
+    private Long calculateDuration() {
+        Duration duration = Duration.between(startDate, endDate);
+        if(duration.isNegative()) return 0L;
+        else return duration.getSeconds();
+    }
 
     public StatisticsDTO() { }
+
+    public StatisticsDTO(final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate) {
+        this.issueId = issueId;
+        this.projectId = projectId;
+        this.priority = priority;
+        this.startDate = startDate;
+        this.duration = calculateDuration();
+    }
+
+    public StatisticsDTO(final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate,
+                         final LocalDateTime endDate,
+                         final MainCause mainCause) {
+        this.issueId = issueId;
+        this.projectId = projectId;
+        this.priority = priority;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.duration = calculateDuration();
+        this.mainCause = mainCause;
+    }
+
+    public StatisticsDTO(final Long id, final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate,
+                         final LocalDateTime endDate,
+                         final MainCause mainCause) {
+        this.id = id;
+        this.issueId = issueId;
+        this.projectId = projectId;
+        this.priority = priority;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.duration = calculateDuration();
+        this.mainCause = mainCause;
+    }
 }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/entity/StatisticsEntity.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/entity/StatisticsEntity.java
@@ -1,10 +1,15 @@
 package com.softgallery.issuemanagementbackEnd.entity;
 
+import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
+import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -20,4 +25,24 @@ public class StatisticsEntity {
 
     @NonNull
     private Long issueId;
+
+    @NonNull
+    private Long projectId;
+
+    @Enumerated(EnumType.STRING)
+    @NonNull
+    private Priority priority;
+
+    @NonNull
+    private LocalDateTime startDate;
+
+    @NonNull
+    private LocalDateTime endDate;
+
+    @NonNull
+    private Long duration;
+
+    @Enumerated(EnumType.STRING)
+    @NonNull
+    private MainCause mainCause;
 }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/repository/StatisticsRepository.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/repository/StatisticsRepository.java
@@ -1,0 +1,37 @@
+package com.softgallery.issuemanagementbackEnd.repository;
+
+import com.softgallery.issuemanagementbackEnd.dto.StatisticsDTO;
+import com.softgallery.issuemanagementbackEnd.entity.StatisticsEntity;
+import com.softgallery.issuemanagementbackEnd.exception.ObjectNotFoundException;
+import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
+import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
+import com.softgallery.issuemanagementbackEnd.service.issue.State;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatisticsRepository extends JpaRepository<StatisticsEntity, Long> {
+    @Override
+    <S extends StatisticsEntity> S save(S entity);
+
+    @Override
+    Optional<StatisticsEntity> findById(Long aLong);
+
+    // Method for statistics derived by all issues
+    Long countByPriority(Priority priority);
+    Long countByDuration(Long duration);
+    Long countByMainCause(MainCause mainCause);
+    Long countByState(State state);
+
+
+    // Method for statistics derived by issues in a certain project
+    // @Query("SELECT COUNT(*) FROM project_member WHERE projectId={projectId} AND priority={priority}")
+    Long countByProjectIdAndPriority(Long projectId, Priority priority);
+    Long countByProjectIdAndDuration(Long projectId, Long duration);
+    Long countByProjectIdAndMainCause(Long projectId, MainCause mainCause);
+    Long countByProjectId(Long projectId);
+    Long countByProjectIdAndState(Long projectId, State state);
+
+    @Override
+    void deleteById(Long aLong);
+}

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/issue/MainCause.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/issue/MainCause.java
@@ -1,0 +1,12 @@
+package com.softgallery.issuemanagementbackEnd.service.issue;
+
+public enum MainCause {
+    RESOLVING,     // 이슈 해결 중 (default value)
+    TYPO,          // 단순 오타,
+    FEATURE,       // 프로그램 기능 구현 문제 (function, method ...)
+    LOGIC,         // 논리구조 문제 (예외처리 누락, 고려하지 못한 Use Case 등)
+    STRUCTURE,     // 프로그램 설계 구조 문제
+    CONFIGURATION, // 설정 및 외부 dependency 문제
+    INFRA,         // DB, 네트워크, 클라우드 등 Infrastructure 문제
+    DOCUMENTATION, // 문서화 문제
+}

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsService.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsService.java
@@ -1,0 +1,183 @@
+package com.softgallery.issuemanagementbackEnd.service.statistics;
+
+import com.softgallery.issuemanagementbackEnd.dto.IssueDTO;
+import com.softgallery.issuemanagementbackEnd.dto.StatisticsDTO;
+import com.softgallery.issuemanagementbackEnd.entity.StatisticsEntity;
+import com.softgallery.issuemanagementbackEnd.exception.ObjectNotFoundException;
+import com.softgallery.issuemanagementbackEnd.repository.ProjectRepository;
+import com.softgallery.issuemanagementbackEnd.repository.StatisticsRepository;
+import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
+import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
+import com.softgallery.issuemanagementbackEnd.service.issue.State;
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StatisticsService implements StatisticsServiceIF {
+    private final StatisticsRepository statisticsRepository;
+    private final ProjectRepository projectRepository;
+
+    public StatisticsService(final StatisticsRepository statisticsRepository, final ProjectRepository projectRepository) {
+        this.statisticsRepository = statisticsRepository;
+        this.projectRepository = projectRepository;
+    }
+
+    @Override
+    public Boolean createIssueStatistics(final IssueDTO issueDTO) {
+//        Long projectId = issueDTO.getProjectId();
+//        LocalDateTime startDate = projectRepository.
+
+        // issue 구조 변경 필요
+        return null;
+    }
+
+    @Override
+    public StatisticsDTO getStatisticsByID(final Long statisticsId) throws ObjectNotFoundException {
+        Optional<StatisticsEntity> statisticsEntityOptional = statisticsRepository.findById(statisticsId);
+        if(statisticsEntityOptional.isEmpty()) throw new ObjectNotFoundException("No such statistics entity");
+
+        StatisticsEntity statisticsEntity = statisticsEntityOptional.get();
+        StatisticsDTO statisticsDTO = new StatisticsDTO(
+                statisticsEntity.getStatisticsId(),
+                statisticsEntity.getIssueId(),
+                statisticsEntity.getProjectId(),
+                statisticsEntity.getPriority(),
+                statisticsEntity.getStartDate(),
+                statisticsEntity.getEndDate(),
+                statisticsEntity.getMainCause()
+        );
+
+        return statisticsDTO;
+    }
+
+    // 전체 이슈 개수
+    @Override
+    public Long getNumberOfAllIssues() {
+        return statisticsRepository.count();
+    }
+
+    // 각 우선순위 별 전체 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfAllIssuesByPriority() {
+        HashMap<String, Long> mapPriorityIssueId = new HashMap<>();
+
+        for(Priority priority : Priority.values()) {
+            mapPriorityIssueId.put(
+                    priority.name(),
+                    statisticsRepository.countByPriority(priority));
+        }
+        return mapPriorityIssueId;
+    }
+
+
+    // 각 이슈 원인 별 전체 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfAllIssuesByMainCause() {
+        HashMap<String, Long> mapMainCauseIssueId = new HashMap<>();
+
+        for(MainCause mainCause : MainCause.values()) {
+            mapMainCauseIssueId.put(
+                    mainCause.name(),
+                    statisticsRepository.countByMainCause(mainCause));
+        }
+        return mapMainCauseIssueId;
+    }
+
+    // 각 이슈 상태 별 전체 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfIssuesByState() {
+        HashMap<String, Long> mapStateIssueId = new HashMap<>();
+
+        for(State state : State.values()) {
+            mapStateIssueId.put(
+                    state.name(),
+                    statisticsRepository.countByState(state)
+            );
+        }
+        return mapStateIssueId;
+    }
+
+    // 각 프로젝트의 전체 이슈 개수
+    @Override
+    public Long getNumberOfIssuesByProject(final Long projectId) {
+        return statisticsRepository.countByProjectId(projectId);
+    }
+
+    // 각 우선순위 별 프로젝트 내 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfIssuesByProjectAndPriority(final Long projectId) {
+        HashMap<String, Long> mapPriorityIssueId = new HashMap<>();
+
+        for(Priority priority : Priority.values()) {
+            mapPriorityIssueId.put(
+                    priority.name(),
+                    statisticsRepository.countByProjectIdAndPriority(projectId, priority));
+        }
+        return mapPriorityIssueId;
+    }
+
+    // 각 이슈 원인 별 프로젝트 내 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfIssuesByProjectAndMainCause(final Long projectId) {
+        HashMap<String, Long> mapMainCauseIssueId = new HashMap<>();
+
+        for(MainCause mainCause : MainCause.values()) {
+            mapMainCauseIssueId.put(
+                    mainCause.name(),
+                    statisticsRepository.countByProjectIdAndMainCause(projectId, mainCause));
+        }
+        return mapMainCauseIssueId;
+    }
+
+    // 각 이슈 상태 별 프로젝트 내 이슈 개수
+    @Override
+    public HashMap<String, Long> getNumberOfIssuesByProjectAndState(final Long projectId) {
+        HashMap<String, Long> mapStateIssueId = new HashMap<>();
+
+        for(State state : State.values()) {
+            mapStateIssueId.put(
+                    state.name(),
+                    statisticsRepository.countByProjectIdAndState(projectId, state)
+            );
+        }
+        return mapStateIssueId;
+    }
+
+    @Override
+    @Transactional
+    public Boolean updateIssueStatistics(final StatisticsDTO statisticsDTO, final Long id) throws ObjectNotFoundException {
+        Optional<StatisticsEntity> oldStatisticsEntity = statisticsRepository.findById(id);
+
+        if(oldStatisticsEntity.isEmpty()) throw new ObjectNotFoundException("No such issue statistics");
+
+        try {
+            StatisticsEntity statistics = oldStatisticsEntity.get();
+            statistics.setIssueId(statisticsDTO.getIssueId());
+            statistics.setProjectId(statisticsDTO.getProjectId());
+            statistics.setPriority(statisticsDTO.getPriority());
+            statistics.setStartDate(statisticsDTO.getStartDate());
+            statistics.setEndDate(statisticsDTO.getEndDate());
+            statistics.setDuration(statisticsDTO.getDuration());
+            statistics.setMainCause(statisticsDTO.getMainCause());
+
+            statisticsRepository.save(statistics);
+            return true;
+        } catch (IllegalArgumentException e) { return false; }
+    }
+
+    @Override
+    @Transactional
+    public Boolean deleteIssueStatistics(final Long id) {
+        try {
+            statisticsRepository.deleteById(id);
+            return true;
+        } catch (RuntimeException e) {
+            e.getStackTrace();
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsServiceIF.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsServiceIF.java
@@ -1,0 +1,36 @@
+package com.softgallery.issuemanagementbackEnd.service.statistics;
+
+import com.softgallery.issuemanagementbackEnd.dto.IssueDTO;
+import com.softgallery.issuemanagementbackEnd.dto.StatisticsDTO;
+import com.softgallery.issuemanagementbackEnd.exception.ObjectNotFoundException;
+import java.util.HashMap;
+
+public interface StatisticsServiceIF {
+    Boolean createIssueStatistics(IssueDTO issueDTO);
+
+    StatisticsDTO getStatisticsByID(Long statisticsId) throws ObjectNotFoundException;
+
+
+    // statistics in global region
+    Long getNumberOfAllIssues();
+
+    HashMap<String, Long> getNumberOfAllIssuesByPriority();
+
+    HashMap<String, Long> getNumberOfAllIssuesByMainCause();
+
+    HashMap<String, Long> getNumberOfIssuesByState();
+
+
+    // statistics in certain project region
+    Long getNumberOfIssuesByProject(Long projectId);
+
+    HashMap<String, Long> getNumberOfIssuesByProjectAndPriority(Long projectId);
+
+    HashMap<String, Long> getNumberOfIssuesByProjectAndMainCause(Long projectId);
+
+    HashMap<String, Long> getNumberOfIssuesByProjectAndState(Long projectId);
+
+    Boolean updateIssueStatistics(StatisticsDTO statisticsDTO, Long id) throws ObjectNotFoundException;
+
+    Boolean deleteIssueStatistics(Long id);
+}


### PR DESCRIPTION
## 💬리뷰 참고사항
- 절대 **완성된 코드가 아니라는걸** 꼭 인지하시고 리뷰 부탁드립니다. 
- 현재 create 로직과 일부 read 로직은 각 이슈의 생성시간과 종료시간에 대한 정보를 필요로 합니다. 이 정보를 받아오기 위해서는 이슈 테이블 스키마의 수정이 필요하여 DB 구조 충돌을 방지하고자 일단 개발을 연기했으며, 이후 이슈에서 개발할 예정입니다.
- 제가 작업하던 branch가 dev의 최신 사항이 반영이 되지 않은 branch여서 그동안 바뀐 스키마 구조를 적용하지 못한 채로 개발을 진행했었습니다. 이에 위와 동일하게 DB 구조 충돌 문제를 방지하고자 Postman 테스트를 안 하고 먼저 PR을 올리게 되었습니다. 이후 이슈에서 테스트 따로 진행하겠습니다. 
- MainCause enum 객체는 각 이슈가 발생했던 주요 원인을 판정하는 값으로, TYPO(단순 오타), FEATURE(기능 구현 문제) 등 8개의 값으로 이루어져 있습니다. 원한다면 나중에 값을 더 추가하셔도 됩니다.
- 서비스의 get 메서드는 현재 DB에 저장되어 있는 모든 이슈의 통계자료를 불러오는 메서드와, projectId 값을 인자로 받아 해당 프로젝트 안에 포함된 모든 이슈의 통계자료를 불러오는 2가지 방식으로 구분됩니다.
- 또한, 각 방식의 메서드는 Priority, MainCause, State 값을 구분자(범례)로 하여 각 항목에 따른 레코드의 개수를 구하는 형식으로 구현되어 있습니다.
- DB 내 모든 이슈를 바탕으로 만들어진 통계자료는 Dashboard 페이지에, 각 프로젝트별 이슈의 통계자료는 프로젝트 상세 페이지 내 통계분석 탭에서 확인이 가능하도록 할 생각이지만, Front의 요청에 따라 달라질 수 있습니다. 


## #️⃣연관된 이슈
- Feat#22 이슈 통계정보 생성 및 전달
