### PR TITLE
[Feat#30] API문서화를 위한 Swagger 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.5'
 	id 'io.spring.dependency-management' version '1.1.4'
+	id "org.springdoc.openapi-gradle-plugin" version "1.8.0"
 }
 
 group = 'com.softgallery'
@@ -50,6 +51,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'junit:junit:4.12'
+
+	//  SpringDoc
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/config/SecurityConfig.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/config/SecurityConfig.java
@@ -28,6 +28,12 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
 
+    private static final String[] AUTH_WHITELIST = {
+            "/user/signup", "/user/signin", "/",
+            "/api/**", "/graphiql", "/graphql",
+            "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html"
+    };
     @Value("${allowed.origin}")
     String allowedOrigin;
 
@@ -54,9 +60,7 @@ public class SecurityConfig {
                 .formLogin((auth) -> auth.disable())
                 .httpBasic((auth) -> auth.disable())
                 .authorizeHttpRequests(request -> request
-                        .requestMatchers(
-                                "/user/signup", "/user/signin", "/"
-                        )
+                        .requestMatchers(AUTH_WHITELIST)
                         .permitAll()
                         .requestMatchers("/admin").hasRole("ADMIN")
                         .requestMatchers("/pl", "/issue/assignment/*/*").hasRole("PL")

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/config/SwaggerConfig.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/config/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.softgallery.issuemanagementbackEnd.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI(){
+
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+        return new OpenAPI()
+                .info(new Info().title("Project Panda's API")
+                        .description("Why is there a 'panda' in the name? There's a sad story there...\nWe don't get enough sleep and we have dark circles as a result.\nWe are becoming more and more like pandas.\nCheers.")
+                        .version("v0.0.1"))
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement);
+
+    }
+}

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/controller/issue/IssueController.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/controller/issue/IssueController.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Controller
 @RequestMapping("/issue")
 @ResponseBody
+
 public class IssueController {
     private IssueServiceIF issueServiceIF;
 


### PR DESCRIPTION
## 💬리뷰 참고사항
#Swagger 사용방법
1. [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)에 접속한다.
3. Authorize 버튼을 누른다.
4. Value에 토큰값을 입력한다. <- 토큰값은 postman에 있는 TOKEN_ADMIN의 값을 입력하면됩니다. Bearer 같은거 안붙이고 토큰 자체만 붙여넣기 하면 됩니다.
5. api포멧에 맞춰서 테스트를 한다.

- SecurityConfig의 변동사항
AUTH_WHITELIST추가: Swagger 웹사이트 진입을 위해 url을 추가하다가, 따로 모아두면 깔끔할 것 같아서 추가했습니다. 개중에 쓰이지 않는 url도 있는데, 나중에 swagger에 대한 이해도가 높아지면 정리가 필요해보입니다.

- SwaggerConfig
swagger사이트에 어떤 요소가 나오게 할지 정하는 configration입니다.
title, description, version같이 사소한 것부터,
서버에게 보낼 authorization key를 입력할 수 있는 버튼도 있게 했습니다.

- application.properies
여기에 swagger에 관련한 환경설정이 여러가지 들어있습니다. 노션에 업데이트 해놨으니 그대로 복사하세요

- build.gradle
Swagger + 
Spring과 Swagger를 연결시켜줄 SpringDoc 추가

## #️⃣연관된 이슈
Spring에서 제공하는 어노테이션만으로 충분히 API에 대한 설명이 되어있지만,
Swagger 사이트의 요소들, API설명, 태그 등등을 좀 더 눈에 편하게 보이게 하려면 Swagger의 어노테이션을 따로 코드에 삽입하면 됩니다. 어렵진 않지만 귀찮은 작업이라 일단은 이대로 올립니다.

