### PR TITLE
[Refactor#31] 이슈 통계정보 CRUD 개선 (1차)

### DIFF
--- a/src/main/java/com/softgallery/issuemanagementbackEnd/controller/issue/IssueController.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/controller/issue/IssueController.java
@@ -12,7 +12,7 @@ import java.util.List;
 @RequestMapping("/issue")
 @ResponseBody
 public class IssueController {
-    private IssueServiceIF issueServiceIF;
+    private final IssueServiceIF issueServiceIF;
 
     public IssueController(final IssueServiceIF issueServiceIF) {
         this.issueServiceIF = issueServiceIF;

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/dto/IssueDTO.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/dto/IssueDTO.java
@@ -2,6 +2,7 @@ package com.softgallery.issuemanagementbackEnd.dto;
 
 import com.softgallery.issuemanagementbackEnd.entity.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
@@ -20,22 +21,25 @@ public class IssueDTO {
     private UserDTO fixer;
     private Long projectId;
     private List<CommentEntity> comments;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate = LocalDateTime.MIN;
 
     public IssueDTO() { }
 
     public IssueDTO(final Long id, final String title, final String description, final UserDTO reporter,
-                    final State status, final Priority priority) {
+                    final State status, final Priority priority, final LocalDateTime startDate) {
         this.id = id;
         this.title = title;
         this.description = description;
         this.reporter = reporter;
         this.status = status;
         this.priority = priority;
+        this.startDate = startDate;
     }
 
     public IssueDTO(final Long id, final String title, final String description, final UserDTO reporter,
                     final State status, final Priority priority,
-                    final UserDTO assignee) {
+                    final UserDTO assignee, final LocalDateTime startDate) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -43,11 +47,14 @@ public class IssueDTO {
         this.status = status;
         this.priority = priority;
         this.assignee = assignee;
+        this.startDate = startDate;
     }
 
     public IssueDTO(final Long id, final String title, final String description, final UserDTO reporter,
                     final State status, final Priority priority,
-                    final UserDTO assignee, final List<CommentEntity> comments, final UserDTO fixer, final Long projectId) {
+                    final UserDTO assignee, final List<CommentEntity> comments,
+                    final UserDTO fixer, final Long projectId,
+                    final LocalDateTime startDate) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -58,5 +65,25 @@ public class IssueDTO {
         this.comments = comments;
         this.fixer = fixer;
         this.projectId = projectId;
+        this.startDate = startDate;
+    }
+
+    public IssueDTO(final Long id, final String title, final String description, final UserDTO reporter,
+                    final State status, final Priority priority,
+                    final UserDTO assignee, final List<CommentEntity> comments,
+                    final UserDTO fixer, final Long projectId,
+                    final LocalDateTime startDate, final LocalDateTime endDate) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.reporter = reporter;
+        this.status = status;
+        this.priority = priority;
+        this.assignee = assignee;
+        this.comments = comments;
+        this.fixer = fixer;
+        this.projectId = projectId;
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
 }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/dto/StatisticsDTO.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/dto/StatisticsDTO.java
@@ -2,6 +2,7 @@ package com.softgallery.issuemanagementbackEnd.dto;
 
 import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
 import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
+import com.softgallery.issuemanagementbackEnd.service.issue.State;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -15,6 +16,7 @@ public class StatisticsDTO {
     private LocalDateTime startDate;
     private LocalDateTime endDate = LocalDateTime.MIN;
     private Long duration;
+    private State state;
     private MainCause mainCause;
 
     // Duration(시간차) Long 값으로 전달
@@ -26,16 +28,18 @@ public class StatisticsDTO {
 
     public StatisticsDTO() { }
 
-    public StatisticsDTO(final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate) {
+    public StatisticsDTO(final Long issueId, final Long projectId, final Priority priority,
+                         final LocalDateTime startDate, final State state) {
         this.issueId = issueId;
         this.projectId = projectId;
         this.priority = priority;
         this.startDate = startDate;
         this.duration = calculateDuration();
+        this.state = state;
     }
 
     public StatisticsDTO(final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate,
-                         final LocalDateTime endDate,
+                         final LocalDateTime endDate, final State state,
                          final MainCause mainCause) {
         this.issueId = issueId;
         this.projectId = projectId;
@@ -43,11 +47,12 @@ public class StatisticsDTO {
         this.startDate = startDate;
         this.endDate = endDate;
         this.duration = calculateDuration();
+        this.state = state;
         this.mainCause = mainCause;
     }
 
     public StatisticsDTO(final Long id, final Long issueId, final Long projectId, final Priority priority, final LocalDateTime startDate,
-                         final LocalDateTime endDate,
+                         final LocalDateTime endDate, final State state,
                          final MainCause mainCause) {
         this.id = id;
         this.issueId = issueId;
@@ -56,6 +61,7 @@ public class StatisticsDTO {
         this.startDate = startDate;
         this.endDate = endDate;
         this.duration = calculateDuration();
+        this.state = state;
         this.mainCause = mainCause;
     }
 }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/entity/IssueEntity.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/entity/IssueEntity.java
@@ -4,9 +4,11 @@ import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
 import com.softgallery.issuemanagementbackEnd.service.issue.State;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Getter
@@ -42,4 +44,12 @@ public class IssueEntity {
 
     @NonNull
     private Long projectId;
+
+    @NonNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime startDate;
+
+    @NonNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime endDate;
 }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/entity/StatisticsEntity.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/entity/StatisticsEntity.java
@@ -2,6 +2,7 @@ package com.softgallery.issuemanagementbackEnd.entity;
 
 import com.softgallery.issuemanagementbackEnd.service.issue.MainCause;
 import com.softgallery.issuemanagementbackEnd.service.issue.Priority;
+import com.softgallery.issuemanagementbackEnd.service.issue.State;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -41,6 +42,9 @@ public class StatisticsEntity {
 
     @NonNull
     private Long duration;
+
+    @NonNull
+    private State state;
 
     @Enumerated(EnumType.STRING)
     @NonNull

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsService.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/statistics/StatisticsService.java
@@ -28,11 +28,23 @@ public class StatisticsService implements StatisticsServiceIF {
 
     @Override
     public Boolean createIssueStatistics(final IssueDTO issueDTO) {
-//        Long projectId = issueDTO.getProjectId();
-//        LocalDateTime startDate = projectRepository.
+        StatisticsEntity statisticsEntity = new StatisticsEntity();
 
-        // issue 구조 변경 필요
-        return null;
+        try {
+            statisticsEntity.setIssueId(issueDTO.getId());
+            statisticsEntity.setProjectId(issueDTO.getProjectId());
+            statisticsEntity.setPriority(issueDTO.getPriority());
+            statisticsEntity.setStartDate(issueDTO.getStartDate());
+            statisticsEntity.setEndDate(issueDTO.getEndDate());
+            statisticsEntity.setState(issueDTO.getStatus());
+            statisticsEntity.setMainCause(MainCause.RESOLVING);
+
+            statisticsRepository.save(statisticsEntity);
+            return true;
+        } catch (RuntimeException e) {
+            System.out.println(e.getStackTrace());
+            return false;
+        }
     }
 
     @Override
@@ -48,6 +60,7 @@ public class StatisticsService implements StatisticsServiceIF {
                 statisticsEntity.getPriority(),
                 statisticsEntity.getStartDate(),
                 statisticsEntity.getEndDate(),
+                statisticsEntity.getState(),
                 statisticsEntity.getMainCause()
         );
 
@@ -162,6 +175,7 @@ public class StatisticsService implements StatisticsServiceIF {
             statistics.setStartDate(statisticsDTO.getStartDate());
             statistics.setEndDate(statisticsDTO.getEndDate());
             statistics.setDuration(statisticsDTO.getDuration());
+            statistics.setState(statisticsDTO.getState());
             statistics.setMainCause(statisticsDTO.getMainCause());
 
             statisticsRepository.save(statistics);


### PR DESCRIPTION
## 💬리뷰 참고사항
- DB 스키마 구조 변경사항
   - Issue table : startDate, endDate 필드 추가 - 이슈별 통계 정보 작성에 사용
   - Statistics table : state 필드 추가 - 이슈 진행상황(state) 정보 저장 후 통계 정보 작성에 활용
- 통계 정보 로직 변경사항
   - 스키마 변경사항에 맞춰 create 로직 구현
   - 스키마 변경사항에 맞춰 DTO, service, controller 메서드 수정
   - 추가 변경사항 발생 시 2차 개발 예정

## #️⃣연관된 이슈
- [REFACTOR#31] 이슈 통계정보 CRUD 개선
