### PR TITLE
[Refactor#70] 프로젝트 생성 로직 리턴타입 변경

### DIFF
--- a/src/main/java/com/softgallery/issuemanagementbackEnd/controller/project/ProjectController.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/controller/project/ProjectController.java
@@ -4,6 +4,7 @@ import com.softgallery.issuemanagementbackEnd.dto.project.ProjectDTO;
 import com.softgallery.issuemanagementbackEnd.service.project.ProjectServiceIF;
 
 import com.softgallery.issuemanagementbackEnd.service.project.ProjectState;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,8 +19,8 @@ public class ProjectController {
     }
 
     @PostMapping("/create")
-    public boolean createProject(@RequestBody ProjectDTO projectDTO, @RequestHeader(name="Authorization") String token){
-        return projectService.createProject(projectDTO, token);
+    public ResponseEntity<Long> createProject(@RequestBody ProjectDTO projectDTO, @RequestHeader(name="Authorization") String token){
+        return ResponseEntity.ok().body(projectService.createProject(projectDTO, token));
     }
 
     @GetMapping("/selection/{projectId}")

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectService.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectService.java
@@ -10,6 +10,7 @@ import com.softgallery.issuemanagementbackEnd.repository.project.ProjectReposito
 import com.softgallery.issuemanagementbackEnd.service.projectMember.ProjectMemberService;
 import com.softgallery.issuemanagementbackEnd.service.user.UserService;
 
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +33,7 @@ public class ProjectService implements ProjectServiceIF {
     }
 
     @Override
+    @Transactional
     public Long createProject(final ProjectDTO projectDTO, final String token) {
 
         try {

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectService.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectService.java
@@ -32,7 +32,7 @@ public class ProjectService implements ProjectServiceIF {
     }
 
     @Override
-    public boolean createProject(final ProjectDTO projectDTO, final String token) {
+    public Long createProject(final ProjectDTO projectDTO, final String token) {
 
         try {
             ProjectEntity projectEntity = new ProjectEntity();
@@ -47,9 +47,9 @@ public class ProjectService implements ProjectServiceIF {
             UserDTO adminDTO = userService.getUser(token);
             assignUserToProject(savedProjectEntity.getProjectId(), adminDTO);
 
-            return true;
+            return savedProjectEntity.getProjectId();
         } catch (IllegalArgumentException e){
-            return false;
+            throw new RuntimeException("Failed creating new project");
         }
 
     }

--- a/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectServiceIF.java
+++ b/src/main/java/com/softgallery/issuemanagementbackEnd/service/project/ProjectServiceIF.java
@@ -5,7 +5,7 @@ import com.softgallery.issuemanagementbackEnd.dto.user.UserDTO;
 import com.softgallery.issuemanagementbackEnd.entity.project.ProjectEntity;
 
 public interface ProjectServiceIF {
-    boolean createProject(ProjectDTO projectDTO, String Token);
+    Long createProject(ProjectDTO projectDTO, String Token);
     ProjectDTO getProject(Long id);
     boolean updateProject(ProjectDTO projectDTO);
     boolean deleteProject(Long id);


### PR DESCRIPTION
## 💬리뷰 참고사항
- project/create 엔드포인트의 리턴 값이 boolean(true, false)에서 생성된 프로젝트 아이디(Long)를 반환하는 것으로 바뀌었습니다. 생성이 완료되지 않은 경우 RuntimeException이 발생합니다. 
- 프로젝트 생성이 완료되지 않았을 경우 DB에 아무것도 변경되지 않도록 @Transactional 추가했습니다. 

## #️⃣연관된 이슈
- Refactor#70 프로젝트 생성 프로세스 변경